### PR TITLE
Support single-image prompts from Telegram

### DIFF
--- a/.changeset/bold-eggs-pull.md
+++ b/.changeset/bold-eggs-pull.md
@@ -1,0 +1,5 @@
+---
+"opencode-telegram-bridge": minor
+---
+
+Add support for sending a single Telegram image (photo or image document) as a prompt to OpenCode.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 # OpenCode Telegram Bridge
 
 ## Project goal
-Run a Telegram bot that forwards messages to an OpenCode backend and returns responses. The MVP focuses on reliable message intake, allowlisted access, and clean service operation with text-only request/response.
+Run a Telegram bot that forwards Telegram messages to an OpenCode backend and returns responses. The MVP focuses on reliable message intake, allowlisted access, and clean service operation with text + single-image request/response.
 
 ## Documentation guidelines
 - Keep documentation (README, docs, AGENTS) lean, extremely clear, and always up to date.

--- a/src/bot-logic.ts
+++ b/src/bot-logic.ts
@@ -44,8 +44,12 @@ export const formatUserLabel = (user: TelegramUser | undefined) => {
   return String(user.id ?? "unknown")
 }
 
-export const isCommandMessage = (message: { entities?: unknown }): boolean => {
-  const entities = message.entities
+export const isCommandMessage = (message: unknown): boolean => {
+  if (typeof message !== "object" || message === null) {
+    return false
+  }
+
+  const entities = (message as { entities?: unknown }).entities
   if (!Array.isArray(entities)) {
     return false
   }

--- a/src/telegram-image.ts
+++ b/src/telegram-image.ts
@@ -1,0 +1,130 @@
+export type TelegramPhotoSize = {
+  file_id: string
+  width: number
+  height: number
+  file_size?: number
+}
+
+export type TelegramDocument = {
+  file_id: string
+  file_name?: string
+  mime_type?: string
+  file_size?: number
+}
+
+export type DownloadLinkProvider = {
+  getFileLink: (fileId: string) => Promise<URL>
+}
+
+export type ImageAttachment = {
+  mime: string
+  filename?: string
+  dataUrl: string
+  byteLength: number
+}
+
+export class TelegramImageTooLargeError extends Error {
+  override name = "TelegramImageTooLargeError"
+
+  constructor(
+    readonly byteLength: number,
+    readonly maxBytes: number,
+  ) {
+    super(
+      `Image too large (${formatBytes(byteLength)}). Limit is ${formatBytes(maxBytes)}.`,
+    )
+  }
+}
+
+export const DEFAULT_MAX_IMAGE_BYTES = 10 * 1024 * 1024
+
+export const isImageDocument = (document: TelegramDocument): boolean => {
+  const mime = document.mime_type
+  if (mime) {
+    return mime.startsWith("image/")
+  }
+
+  const name = document.file_name
+  if (!name) {
+    return false
+  }
+
+  const lowered = name.toLowerCase()
+  return (
+    lowered.endsWith(".png") ||
+    lowered.endsWith(".jpg") ||
+    lowered.endsWith(".jpeg") ||
+    lowered.endsWith(".webp")
+  )
+}
+
+export const pickLargestPhoto = (photos: TelegramPhotoSize[]): TelegramPhotoSize => {
+  if (photos.length === 0) {
+    throw new Error("Expected at least one photo size")
+  }
+
+  const sorted = [...photos].sort((a, b) => {
+    const aArea = a.width * a.height
+    const bArea = b.width * b.height
+    if (aArea !== bArea) {
+      return bArea - aArea
+    }
+    return (b.file_size ?? 0) - (a.file_size ?? 0)
+  })
+  return sorted[0]!
+}
+
+export const buildDataUrl = (mime: string, bytes: Buffer): string => {
+  const base64 = bytes.toString("base64")
+  return `data:${mime};base64,${base64}`
+}
+
+export const downloadTelegramImageAsAttachment = async (
+  telegram: DownloadLinkProvider,
+  fileId: string,
+  options: {
+    mime: string
+    filename?: string
+    maxBytes?: number
+    declaredSize?: number
+  },
+): Promise<ImageAttachment> => {
+  const maxBytes = options.maxBytes ?? DEFAULT_MAX_IMAGE_BYTES
+  const declaredSize = options.declaredSize
+  if (declaredSize != null && declaredSize > maxBytes) {
+    throw new TelegramImageTooLargeError(declaredSize, maxBytes)
+  }
+
+  const url = await telegram.getFileLink(fileId)
+  const response = await fetch(url)
+  if (!response.ok) {
+    throw new Error(`Failed to download Telegram file (status ${response.status})`)
+  }
+
+  const arrayBuffer = await response.arrayBuffer()
+  const bytes = Buffer.from(arrayBuffer)
+  if (bytes.byteLength > maxBytes) {
+    throw new TelegramImageTooLargeError(bytes.byteLength, maxBytes)
+  }
+
+  return {
+    mime: options.mime,
+    ...(options.filename ? { filename: options.filename } : {}),
+    dataUrl: buildDataUrl(options.mime, bytes),
+    byteLength: bytes.byteLength,
+  }
+}
+
+const formatBytes = (bytes: number): string => {
+  const mb = bytes / (1024 * 1024)
+  if (mb >= 1) {
+    return `${mb.toFixed(1)}MB`
+  }
+
+  const kb = bytes / 1024
+  if (kb >= 1) {
+    return `${kb.toFixed(1)}KB`
+  }
+
+  return `${bytes}B`
+}

--- a/tests/bot.handlers.test.ts
+++ b/tests/bot.handlers.test.ts
@@ -294,8 +294,8 @@ describe("bot handler behavior", () => {
       ensureSessionId: vi.fn(async () => "session-1"),
       abortSession: vi.fn(async () => true),
       promptFromChat: vi.fn(
-        async (_chatId: number, text: string, _dir: string, options?: any) => {
-          if (text === "second") {
+        async (_chatId: number, input: any, _dir: string, options?: any) => {
+          if (input?.text === "second") {
             return { reply: "ok", model: null }
           }
 

--- a/tests/opencode-image-support.test.ts
+++ b/tests/opencode-image-support.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it, vi } from "vitest"
+
+vi.mock("@opencode-ai/sdk/v2", () => {
+  return {
+    createOpencodeClient: () => {
+      return {
+        session: {
+          create: vi.fn(async () => ({ data: { id: "session-1" } })),
+          prompt: vi.fn(async () => {
+            throw new Error("prompt should not be called")
+          }),
+          abort: vi.fn(async () => ({ data: true })),
+        },
+        config: {
+          get: vi.fn(async () => ({ data: { model: "openai/gpt-4.1" } })),
+          providers: vi.fn(async () => ({
+            data: {
+              providers: [
+                {
+                  id: "openai",
+                  models: {
+                    "gpt-4.1": {
+                      capabilities: { input: { image: false } },
+                    },
+                  },
+                },
+              ],
+            },
+          })),
+        },
+        permission: {
+          reply: vi.fn(async () => ({ data: true })),
+        },
+        global: {
+          event: vi.fn(async () => ({
+            stream: (async function* () {
+              return
+            })(),
+          })),
+        },
+      }
+    },
+  }
+})
+
+import { createOpencodeBridge } from "../src/opencode.js"
+
+describe("opencode image capability checks", () => {
+  it("throws a clear error when model does not support image input", async () => {
+    const bridge = createOpencodeBridge({
+      serverUrl: "http://localhost:3000",
+      serverUsername: "opencode",
+    })
+
+    await expect(
+      bridge.promptFromChat(
+        123,
+        {
+          text: "analyze",
+          files: [
+            {
+              mime: "image/png",
+              dataUrl: "data:image/png;base64,AA==",
+            },
+          ],
+        },
+        "/tmp",
+      ),
+    ).rejects.toThrow("does not support image input")
+  })
+})

--- a/tests/telegram-image.test.ts
+++ b/tests/telegram-image.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it, vi } from "vitest"
+
+import {
+  DEFAULT_MAX_IMAGE_BYTES,
+  TelegramImageTooLargeError,
+  buildDataUrl,
+  downloadTelegramImageAsAttachment,
+  isImageDocument,
+  pickLargestPhoto,
+} from "../src/telegram-image.js"
+
+describe("telegram-image", () => {
+  it("picks the largest photo by area", () => {
+    const picked = pickLargestPhoto([
+      { file_id: "a", width: 100, height: 100 },
+      { file_id: "b", width: 200, height: 150 },
+      { file_id: "c", width: 300, height: 50 },
+    ])
+    expect(picked.file_id).toBe("b")
+  })
+
+  it("recognizes image documents by mime type", () => {
+    expect(
+      isImageDocument({ file_id: "x", mime_type: "image/png", file_name: "a" }),
+    ).toBe(true)
+    expect(
+      isImageDocument({ file_id: "x", mime_type: "application/pdf", file_name: "a" }),
+    ).toBe(false)
+  })
+
+  it("recognizes image documents by extension when mime is missing", () => {
+    expect(isImageDocument({ file_id: "x", file_name: "test.PNG" })).toBe(true)
+    expect(isImageDocument({ file_id: "x", file_name: "test.pdf" })).toBe(false)
+  })
+
+  it("builds a data url", () => {
+    const url = buildDataUrl("image/png", Buffer.from([1, 2, 3]))
+    expect(url.startsWith("data:image/png;base64,")).toBe(true)
+    expect(url).toContain(Buffer.from([1, 2, 3]).toString("base64"))
+  })
+
+  it("rejects declared oversize before downloading", async () => {
+    const telegram = {
+      getFileLink: vi.fn(async () => new URL("https://example.com/file")),
+    }
+    await expect(
+      downloadTelegramImageAsAttachment(telegram, "file", {
+        mime: "image/png",
+        declaredSize: DEFAULT_MAX_IMAGE_BYTES + 1,
+        maxBytes: DEFAULT_MAX_IMAGE_BYTES,
+      }),
+    ).rejects.toBeInstanceOf(TelegramImageTooLargeError)
+    expect(telegram.getFileLink).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
Closes #16.

What changed:
- Accept Telegram photo messages and image document messages (with caption) and forward as OpenCode file parts via data URLs
- Check OpenCode provider capabilities and return a clear error when the active model does not support image input
- Add unit tests for image helpers + unsupported-model error handling

Notes:
- Current MVP supports a single image per message. Telegram albums (media groups) will still mostly be ignored due to the per-chat in-flight guard.
- Photo MIME is assumed as image/jpeg for Telegram photo updates.