### PR TITLE
Surface OpenCode tool-call progress in Telegram

### DIFF
--- a/.changeset/tidy-lobsters-visit.md
+++ b/.changeset/tidy-lobsters-visit.md
@@ -1,0 +1,5 @@
+---
+"opencode-telegram-bridge": patch
+---
+
+Surface OpenCode tool-call progress in Telegram by forwarding tool-part event updates as live per-call status messages.

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -11,6 +11,7 @@ import type {
   OpencodeBridge,
   PermissionReply,
   PromptInput,
+  ToolCallPart,
 } from "./opencode.js"
 import { createPromptGuard } from "./prompt-guard.js"
 import { HOME_PROJECT_ALIAS, type ProjectStore } from "./projects.js"
@@ -79,6 +80,12 @@ type RestartResult =
       error?: Error
     }
 
+type ToolCallStatusMessage = {
+  chatId: number
+  messageId: number
+  lastRenderedText: string
+}
+
 const execAsync = promisify(exec)
 
 export const toTelegrafInlineKeyboard = (
@@ -137,6 +144,7 @@ export const startBot = (
   const pendingPermissions = new Map<string, PendingPermission>()
   const pendingQuestions = new Map<string, PendingQuestion>()
   const pendingQuestionsByChat = new Map<number, string>()
+  const toolCallMessages = new Map<string, ToolCallStatusMessage>()
 
   const sendReply = async (
     chatId: number,
@@ -189,6 +197,108 @@ export const startBot = (
       "[user_message]",
       text,
     ].join("\n")
+  }
+
+  const buildToolCallKey = (part: ToolCallPart) =>
+    `${part.sessionID}\u0000${part.messageID}\u0000${part.callID}`
+
+  const toCompactJson = (value: unknown, maxLength: number) => {
+    if (value == null) {
+      return ""
+    }
+
+    const raw = (() => {
+      if (typeof value === "string") {
+        return value
+      }
+
+      try {
+        return JSON.stringify(value)
+      } catch {
+        return String(value)
+      }
+    })()
+
+    return truncate(raw, maxLength)
+  }
+
+  const renderToolCallStatus = (part: ToolCallPart) => {
+    const state = part.state
+    const lines = [
+      "OpenCode tool call",
+      `Tool: ${part.tool}`,
+      `Status: ${state.status}`,
+      `Call ID: ${part.callID}`,
+    ]
+
+    const inputPreview = toCompactJson(state.input, 900)
+    if (inputPreview) {
+      lines.push("", "Input:", inputPreview)
+    }
+
+    if (state.status === "completed") {
+      const outputPreview = toCompactJson(state.output, 1400)
+      if (outputPreview) {
+        lines.push("", "Output:", outputPreview)
+      }
+    }
+
+    if (state.status === "error") {
+      const errorText = truncate(state.error, 1400)
+      lines.push("", "Error:", errorText)
+    }
+
+    return truncate(lines.join("\n"), 3800)
+  }
+
+  const upsertToolCallStatusMessage = async (part: ToolCallPart, chatId: number) => {
+    const key = buildToolCallKey(part)
+    const rendered = renderToolCallStatus(part)
+    const existing = toolCallMessages.get(key)
+
+    if (!existing) {
+      const message = await bot.telegram.sendMessage(chatId, rendered)
+      toolCallMessages.set(key, {
+        chatId,
+        messageId: message.message_id,
+        lastRenderedText: rendered,
+      })
+      return
+    }
+
+    if (existing.lastRenderedText === rendered) {
+      return
+    }
+
+    try {
+      await bot.telegram.editMessageText(chatId, existing.messageId, undefined, rendered)
+      toolCallMessages.set(key, {
+        chatId,
+        messageId: existing.messageId,
+        lastRenderedText: rendered,
+      })
+      return
+    } catch (error) {
+      logger.warn(
+        {
+          error: serializeError(error),
+          chatId,
+          messageId: existing.messageId,
+          callId: part.callID,
+          sessionId: part.sessionID,
+        },
+        "Failed to edit tool status message; sending fallback reply",
+      )
+    }
+
+    const message = await bot.telegram.sendMessage(chatId, rendered, {
+      reply_parameters: { message_id: existing.messageId },
+    })
+    toolCallMessages.set(key, {
+      chatId,
+      messageId: message.message_id,
+      lastRenderedText: rendered,
+    })
   }
 
   const buildQuestionPromptText = (pending: PendingQuestion) => {
@@ -578,6 +688,26 @@ export const startBot = (
         pendingQuestionsByChat.set(owner.chatId, request.id)
       } catch (error) {
         logger.error({ error: serializeError(error) }, "Failed to send question request")
+      }
+    },
+    onToolCallUpdated: async ({ part }) => {
+      const owner = opencode.getSessionOwner(part.sessionID)
+      if (!owner) {
+        logger.warn(
+          {
+            sessionId: part.sessionID,
+            messageId: part.messageID,
+            callId: part.callID,
+          },
+          "Tool call update for unknown session",
+        )
+        return
+      }
+
+      try {
+        await upsertToolCallStatusMessage(part, owner.chatId)
+      } catch (error) {
+        logger.error({ error: serializeError(error) }, "Failed to send tool call status update")
       }
     },
     onError: (error: unknown) => {

--- a/src/opencode.ts
+++ b/src/opencode.ts
@@ -122,6 +122,8 @@ export type PermissionEventHandlers = {
 
 export type QuestionAnswers = Array<Array<string>>
 
+export type ToolCallPart = Extract<Part, { type: "tool" }>
+
 export type EventStreamHandlers = {
   onPermissionAsked?: (event: {
     request: PermissionRequest
@@ -129,6 +131,10 @@ export type EventStreamHandlers = {
   }) => void | Promise<void>
   onQuestionAsked?: (event: {
     request: QuestionRequest
+    directory: string
+  }) => void | Promise<void>
+  onToolCallUpdated?: (event: {
+    part: ToolCallPart
     directory: string
   }) => void | Promise<void>
   onError?: (error: unknown) => void
@@ -608,7 +614,7 @@ export const createOpencodeBridge = (
       const responseResult = await client.question.reject(parameters)
       return requireData(responseResult, "question.reject")
     },
-    startEventStream({ onPermissionAsked, onQuestionAsked, onError }) {
+    startEventStream({ onPermissionAsked, onQuestionAsked, onToolCallUpdated, onError }) {
       const abortController = new AbortController()
 
       const run = async () => {
@@ -648,6 +654,25 @@ export const createOpencodeBridge = (
                     directory: (event as GlobalEvent).directory,
                   }),
                 )
+                continue
+              }
+
+              if (payload?.type === "message.part.updated") {
+                const partEvent = payload as {
+                  type: "message.part.updated"
+                  properties: {
+                    part?: Part
+                  }
+                }
+                const part = partEvent.properties?.part
+                if (part?.type === "tool") {
+                  await Promise.resolve(
+                    onToolCallUpdated?.({
+                      part: part as ToolCallPart,
+                      directory: (event as GlobalEvent).directory,
+                    }),
+                  )
+                }
               }
             }
           } catch (error) {

--- a/tests/bot.handlers.test.ts
+++ b/tests/bot.handlers.test.ts
@@ -3113,6 +3113,288 @@ describe("bot handler behavior", () => {
     expect(bot.telegram.sendMessage).not.toHaveBeenCalled()
   })
 
+  it("tool call updates are ignored for unknown session owner", async () => {
+    const eventHandlers: { onToolCallUpdated?: any } = {}
+
+    const opencode = {
+      promptFromChat: vi.fn(async () => ({ reply: "hi", model: null })),
+      resetSession: vi.fn(() => false),
+      resetAllSessions: vi.fn(() => undefined),
+      getSessionOwner: vi.fn(() => null),
+      listModels: vi.fn(async () => []),
+      replyToPermission: vi.fn(async () => true),
+      startEventStream: vi.fn((handlers: any) => {
+        eventHandlers.onToolCallUpdated = handlers.onToolCallUpdated
+        return { stop: () => undefined }
+      }),
+    }
+    const projects = {
+      listProjects: () => [{ alias: "home", path: "/home/user" }],
+      getProject: () => ({ alias: "home", path: "/home/user" }),
+      addProject: vi.fn(),
+      removeProject: vi.fn(),
+    }
+    const chatProjects = { getActiveAlias: () => null, setActiveAlias: vi.fn() }
+    const chatModels = {
+      getModel: () => null,
+      setModel: vi.fn(),
+      clearModel: vi.fn(),
+      clearAll: vi.fn(),
+    }
+
+    const { startBot } = await import("../src/bot.js")
+    startBot(
+      {
+        botToken: "token",
+        allowedUserIds: [1],
+        opencode: { serverUrl: "http://localhost", serverUsername: "opencode" },
+        handlerTimeoutMs: 9999,
+        promptTimeoutMs: 1000,
+      },
+      opencode as any,
+      projects as any,
+      chatProjects as any,
+      chatModels as any,
+    )
+
+    const state = (globalThis as any).__telegrafMockState as TelegrafMockState
+    const bot = state.lastBot!
+
+    await eventHandlers.onToolCallUpdated({
+      part: {
+        id: "prt-1",
+        sessionID: "session-unknown",
+        messageID: "message-1",
+        type: "tool",
+        callID: "call-1",
+        tool: "read",
+        state: { status: "pending", input: { filePath: "README.md" }, raw: "x" },
+      },
+      directory: "/home/user",
+    })
+
+    expect(bot.telegram.sendMessage).not.toHaveBeenCalled()
+  })
+
+  it("tool call updates create one message and dedupe identical edits", async () => {
+    const eventHandlers: { onToolCallUpdated?: any } = {}
+
+    const opencode = {
+      promptFromChat: vi.fn(async () => ({ reply: "hi", model: null })),
+      resetSession: vi.fn(() => false),
+      resetAllSessions: vi.fn(() => undefined),
+      getSessionOwner: vi.fn(() => ({ chatId: 10, projectDir: "/home/user" })),
+      listModels: vi.fn(async () => []),
+      replyToPermission: vi.fn(async () => true),
+      startEventStream: vi.fn((handlers: any) => {
+        eventHandlers.onToolCallUpdated = handlers.onToolCallUpdated
+        return { stop: () => undefined }
+      }),
+    }
+    const projects = {
+      listProjects: () => [{ alias: "home", path: "/home/user" }],
+      getProject: () => ({ alias: "home", path: "/home/user" }),
+      addProject: vi.fn(),
+      removeProject: vi.fn(),
+    }
+    const chatProjects = { getActiveAlias: () => null, setActiveAlias: vi.fn() }
+    const chatModels = {
+      getModel: () => null,
+      setModel: vi.fn(),
+      clearModel: vi.fn(),
+      clearAll: vi.fn(),
+    }
+
+    const { startBot } = await import("../src/bot.js")
+    startBot(
+      {
+        botToken: "token",
+        allowedUserIds: [1],
+        opencode: { serverUrl: "http://localhost", serverUsername: "opencode" },
+        handlerTimeoutMs: 9999,
+        promptTimeoutMs: 1000,
+      },
+      opencode as any,
+      projects as any,
+      chatProjects as any,
+      chatModels as any,
+    )
+
+    const state = (globalThis as any).__telegrafMockState as TelegrafMockState
+    const bot = state.lastBot!
+    bot.telegram.sendMessage.mockResolvedValueOnce({ message_id: 500 })
+
+    await eventHandlers.onToolCallUpdated({
+      part: {
+        id: "prt-1",
+        sessionID: "session-1",
+        messageID: "message-1",
+        type: "tool",
+        callID: "call-1",
+        tool: "read",
+        state: { status: "pending", input: { filePath: "README.md" }, raw: "x" },
+      },
+      directory: "/home/user",
+    })
+
+    await eventHandlers.onToolCallUpdated({
+      part: {
+        id: "prt-1",
+        sessionID: "session-1",
+        messageID: "message-1",
+        type: "tool",
+        callID: "call-1",
+        tool: "read",
+        state: {
+          status: "running",
+          input: { filePath: "README.md" },
+          time: { start: 100 },
+        },
+      },
+      directory: "/home/user",
+    })
+
+    await eventHandlers.onToolCallUpdated({
+      part: {
+        id: "prt-1",
+        sessionID: "session-1",
+        messageID: "message-1",
+        type: "tool",
+        callID: "call-1",
+        tool: "read",
+        state: {
+          status: "running",
+          input: { filePath: "README.md" },
+          time: { start: 100 },
+        },
+      },
+      directory: "/home/user",
+    })
+
+    expect(bot.telegram.sendMessage).toHaveBeenCalledTimes(1)
+    expect(bot.telegram.editMessageText).toHaveBeenCalledTimes(1)
+    expect(bot.telegram.editMessageText).toHaveBeenCalledWith(
+      10,
+      500,
+      undefined,
+      expect.stringContaining("Status: running"),
+    )
+  })
+
+  it("tool call update falls back to reply message when edit fails", async () => {
+    const eventHandlers: { onToolCallUpdated?: any } = {}
+
+    const opencode = {
+      promptFromChat: vi.fn(async () => ({ reply: "hi", model: null })),
+      resetSession: vi.fn(() => false),
+      resetAllSessions: vi.fn(() => undefined),
+      getSessionOwner: vi.fn(() => ({ chatId: 10, projectDir: "/home/user" })),
+      listModels: vi.fn(async () => []),
+      replyToPermission: vi.fn(async () => true),
+      startEventStream: vi.fn((handlers: any) => {
+        eventHandlers.onToolCallUpdated = handlers.onToolCallUpdated
+        return { stop: () => undefined }
+      }),
+    }
+    const projects = {
+      listProjects: () => [{ alias: "home", path: "/home/user" }],
+      getProject: () => ({ alias: "home", path: "/home/user" }),
+      addProject: vi.fn(),
+      removeProject: vi.fn(),
+    }
+    const chatProjects = { getActiveAlias: () => null, setActiveAlias: vi.fn() }
+    const chatModels = {
+      getModel: () => null,
+      setModel: vi.fn(),
+      clearModel: vi.fn(),
+      clearAll: vi.fn(),
+    }
+
+    const { startBot } = await import("../src/bot.js")
+    startBot(
+      {
+        botToken: "token",
+        allowedUserIds: [1],
+        opencode: { serverUrl: "http://localhost", serverUsername: "opencode" },
+        handlerTimeoutMs: 9999,
+        promptTimeoutMs: 1000,
+      },
+      opencode as any,
+      projects as any,
+      chatProjects as any,
+      chatModels as any,
+    )
+
+    const state = (globalThis as any).__telegrafMockState as TelegrafMockState
+    const bot = state.lastBot!
+    bot.telegram.sendMessage
+      .mockResolvedValueOnce({ message_id: 700 })
+      .mockResolvedValueOnce({ message_id: 701 })
+    bot.telegram.editMessageText
+      .mockRejectedValueOnce(new Error("edit failed"))
+      .mockResolvedValueOnce(undefined)
+
+    await eventHandlers.onToolCallUpdated({
+      part: {
+        id: "prt-1",
+        sessionID: "session-1",
+        messageID: "message-1",
+        type: "tool",
+        callID: "call-1",
+        tool: "read",
+        state: { status: "pending", input: { filePath: "README.md" }, raw: "x" },
+      },
+      directory: "/home/user",
+    })
+
+    await eventHandlers.onToolCallUpdated({
+      part: {
+        id: "prt-1",
+        sessionID: "session-1",
+        messageID: "message-1",
+        type: "tool",
+        callID: "call-1",
+        tool: "read",
+        state: {
+          status: "running",
+          input: { filePath: "README.md" },
+          time: { start: 100 },
+        },
+      },
+      directory: "/home/user",
+    })
+
+    await eventHandlers.onToolCallUpdated({
+      part: {
+        id: "prt-1",
+        sessionID: "session-1",
+        messageID: "message-1",
+        type: "tool",
+        callID: "call-1",
+        tool: "read",
+        state: {
+          status: "completed",
+          input: { filePath: "README.md" },
+          output: "ok",
+          title: "Read",
+          metadata: {},
+          time: { start: 100, end: 120 },
+        },
+      },
+      directory: "/home/user",
+    })
+
+    expect(bot.telegram.sendMessage).toHaveBeenNthCalledWith(2, 10, expect.any(String), {
+      reply_parameters: { message_id: 700 },
+    })
+    expect(bot.telegram.editMessageText).toHaveBeenLastCalledWith(
+      10,
+      701,
+      undefined,
+      expect.stringContaining("Status: completed"),
+    )
+  })
+
   it("callback_query errors: unauthorized / request missing / reply failure", async () => {
     const permissionHandlers: { onPermissionAsked?: any } = {}
 


### PR DESCRIPTION
## Summary
- Add tool-call event handling for `message.part.updated` tool parts in the OpenCode event stream.
- Show one Telegram status message per tool call and update it as the call moves through `pending`, `running`, `completed`, and `error` states.
- De-duplicate identical rendered updates and fall back to a reply message when Telegram edit fails, then continue updates on the new message.
- Add tests for unknown session routing, dedupe behavior, and edit-failure fallback.

## Validation
- `npm run typecheck`
- `npm test`
- `npm run build`

Closes #44