### PR TITLE
Implement graceful shutdown handling for systemd services

### DIFF
--- a/src/bot.ts
+++ b/src/bot.ts
@@ -17,7 +17,7 @@ import { createPromptGuard } from "./prompt-guard.js"
 import { HOME_PROJECT_ALIAS, type ProjectStore } from "./projects.js"
 import type { ChatModelStore, ChatProjectStore } from "./state.js"
 import { splitTelegramMessage } from "./telegram.js"
-import { logger } from "./logger.js"
+import { flushLogger, logger } from "./logger.js"
 import {
   DEFAULT_MAX_IMAGE_BYTES,
   TelegramImageTooLargeError,
@@ -86,6 +86,10 @@ type ToolCallStatusMessage = {
   lastRenderedText: string
 }
 
+export type BotInstance = {
+  stop: (reason: string) => void
+}
+
 const execAsync = promisify(exec)
 
 export const toTelegrafInlineKeyboard = (
@@ -103,7 +107,7 @@ export const startBot = (
   projects: ProjectStore,
   chatProjects: ChatProjectStore,
   chatModels: ChatModelStore,
-): Telegraf => {
+): BotInstance => {
   const bot = new Telegraf(config.botToken, {
     handlerTimeout: config.handlerTimeoutMs,
   })
@@ -696,7 +700,7 @@ export const startBot = (
     }
   }
 
-  opencode.startEventStream({
+  const eventStream = opencode.startEventStream({
     onPermissionAsked: async ({ request, directory }) => {
       const owner = opencode.getSessionOwner(request.sessionID)
       if (!owner) {
@@ -1926,5 +1930,13 @@ export const startBot = (
     .catch((error) =>
       logger.error({ error: serializeError(error) }, "Failed to set private chat commands"),
     )
-  return bot
+  return {
+    stop: (reason) => {
+      eventStream.stop()
+      promptGuard.cancelAll()
+      bot.stop(reason)
+      flushLogger()
+      process.exit(0)
+    },
+  }
 }

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -28,3 +28,7 @@ export const logger = pino(
     { dedupe: true },
   ),
 )
+
+export const flushLogger = () => {
+  logger.flush()
+}

--- a/src/prompt-guard.ts
+++ b/src/prompt-guard.ts
@@ -29,6 +29,7 @@ export type PromptGuard = {
     | null
   finish: (chatId: number) => void
   isInFlight: (chatId: number) => boolean
+  cancelAll: () => void
 }
 
 export const createPromptGuard = (timeoutMs: number): PromptGuard => {
@@ -129,11 +130,18 @@ export const createPromptGuard = (timeoutMs: number): PromptGuard => {
     inFlight.delete(chatId)
   }
 
+  const cancelAll = () => {
+    for (const [chatId] of inFlight) {
+      abort(chatId)
+    }
+  }
+
   return {
     tryStart,
     setSessionId,
     abort,
     finish,
     isInFlight: (chatId) => inFlight.has(chatId),
+    cancelAll,
   }
 }

--- a/systemd/opencode-telegram-bridge.service
+++ b/systemd/opencode-telegram-bridge.service
@@ -9,6 +9,7 @@ EnvironmentFile=%h/.config/opencode-telegram-bridge/opencode-telegram-bridge.env
 ExecStart=/usr/bin/opencode-telegram-bridge
 Restart=on-failure
 RestartSec=3
+TimeoutStopSec=10
 
 [Install]
 WantedBy=default.target

--- a/tests/prompt-guard.test.ts
+++ b/tests/prompt-guard.test.ts
@@ -36,6 +36,24 @@ describe("prompt guard", () => {
     vi.useRealTimers()
   })
 
+  it("cancels all in-flight prompts with cancelAll", () => {
+    const guard = createPromptGuard(1000)
+    const onTimeout = vi.fn()
+
+    const c1 = guard.tryStart(1, 100, onTimeout)
+    const c2 = guard.tryStart(2, 200, onTimeout)
+    expect(c1).not.toBeNull()
+    expect(c2).not.toBeNull()
+
+    guard.cancelAll()
+
+    expect(c1?.signal.aborted).toBe(true)
+    expect(c2?.signal.aborted).toBe(true)
+    expect(guard.isInFlight(1)).toBe(false)
+    expect(guard.isInFlight(2)).toBe(false)
+    expect(onTimeout).toHaveBeenCalledTimes(0)
+  })
+
   it("aborts a prompt and releases the lock", () => {
     const guard = createPromptGuard(1000)
     const onTimeout = vi.fn()

--- a/tests/shutdown.test.ts
+++ b/tests/shutdown.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest"
+
+import type { BotInstance } from "../src/bot.js"
+import { flushLogger } from "../src/logger.js"
+
+describe("shutdown graceful", () => {
+  it("exports the BotInstance type with a stop method", () => {
+    const instance: BotInstance = {
+      stop: () => undefined,
+    }
+
+    expect(instance.stop).toBeInstanceOf(Function)
+  })
+
+  it("flushLogger does not throw", () => {
+    expect(() => flushLogger()).not.toThrow()
+  })
+})


### PR DESCRIPTION
## Description

**Problem:** On systemd shutdown/reboot, the bridge caught SIGTERM but the process never exited (Telegraf pollers, active prompts, and the event stream kept it alive). systemd waited the full 90s default timeout before sending SIGKILL, delaying shutdown.

**Root cause:** `process.once("SIGTERM")` called `bot.stop()` which only stopped Telegraf polling — the event stream and in-flight prompts were left running, preventing process exit.

**Changes:**
- `startBot()` returns `BotInstance` (with a `stop` method) instead of raw `Telegraf.stop()`. `BotInstance.stop()` tears down the event stream, cancels all in-flight prompts, stops the bot, flushes pending log writes, and exits.
- `PromptGuard.cancelAll()` — aborts every in-flight prompt without firing their timeout callbacks.
- `flushLogger()` — ensures all log writes are flushed before exit (defensive, it's a no-op with current config, meaningful if a `pino.transport()` worker is added later).
- `TimeoutStopSec=10` in the systemd unit to cap the timeout.

**How to validate:**
```bash
npm run dev & PID=$!; sleep 2; kill -TERM $PID; sleep 2; kill -TERM $PID && echo "[!] FAIL: server was still running" || echo "[+] SUCCESS server was not running"
```
- *Without fix:* first SIGTERM is caught by the handler --> second SIGTERM falls through to default --> `kill` succeeds --> FAIL.
- *With fix:* first SIGTERM --> `stop()` --> `process.exit(0)` --> second `kill` fails --> SUCCESS.
