### PR TITLE
Support model IDs containing slashes (provider/org/model pattern)

### DIFF
--- a/src/bot.ts
+++ b/src/bot.ts
@@ -1277,11 +1277,13 @@ export const startBot = (
             return
           }
 
-          const [providerID, modelID] = rawModel.split("/")
-          if (!providerID || !modelID) {
-            await ctx.reply("Model must be in provider/model format. Use /model list.")
-            return
+          const slashIndex = rawModel.indexOf("/");
+          if (slashIndex === -1) {
+              await ctx.reply("Model must be in provider/model format. Use /model list.");
+              return;
           }
+          const providerID = rawModel.slice(0, slashIndex);
+          const modelID = rawModel.slice(slashIndex + 1);
 
           try {
             const providers = await opencode.listModels(project.path)

--- a/src/opencode.ts
+++ b/src/opencode.ts
@@ -300,7 +300,12 @@ const requireData = <T>(
 }
 
 const parseModelRef = (value: string): ModelRef => {
-  const [providerID, modelID] = value.split("/")
+  const slashIndex = value.indexOf("/");
+  if (slashIndex === -1) {
+      throw new OpencodeModelFormatError(`Unexpected OpenCode model format: ${value}`);
+  }
+  const providerID = value.slice(0, slashIndex);
+  const modelID = value.slice(slashIndex + 1);
   if (!providerID || !modelID) {
     throw new OpencodeModelFormatError(`Unexpected OpenCode model format: ${value}`)
   }

--- a/tests/bot-logic.commands.test.ts
+++ b/tests/bot-logic.commands.test.ts
@@ -62,4 +62,10 @@ describe("parseModelCommand", () => {
       args: ["openai/gpt-5.2-codex"],
     })
   })
+  it("parses set with openrouter model ref", () => {
+    expect(parseModelCommand("/model set openrouter/z-ai/glm-5.1")).toEqual({
+      subcommand: "set",
+      args: ["openrouter/z-ai/glm-5.1"],
+    })
+  })
 })

--- a/tests/bot.handlers.test.ts
+++ b/tests/bot.handlers.test.ts
@@ -1885,6 +1885,12 @@ describe("bot handler behavior", () => {
             "gpt-5.2": { name: "GPT-5.2" },
           },
         },
+        {
+          id: "openrouter",
+          models: {
+            "z-ai/glm-5.1": { name: "GLM-5.1" },
+          },
+        },
       ]),
       replyToPermission: vi.fn(async () => true),
       startEventStream: vi.fn(() => ({ stop: () => undefined })),
@@ -1957,6 +1963,17 @@ describe("bot handler behavior", () => {
     expect(missingModel.reply).toHaveBeenCalledWith(
       "Model 'openai/missing' not found. Use /model list.",
     )
+
+    const valid_model = createTextCtx({
+      userId: 1,
+      chatId: 10,
+      text: "/model set openrouter/z-ai/glm-5.1",
+    })
+    await bot.dispatchCommand("model", valid_model)
+    expect(valid_model.reply).toHaveBeenCalledWith(
+      "Current model set to openrouter/z-ai/glm-5.1.",
+    )
+    expect(storedModel).toEqual({ providerID: "openrouter", modelID: "z-ai/glm-5.1" })
 
     const success = createTextCtx({
       userId: 1,


### PR DESCRIPTION
Some OpenCode providers expose models under an organizational prefix, producing refs like `provider/ai-company/model` (e.g. `openrouter/z-ai/glm-5.1`). These broke because `String.split("/")` splits on every `/`, so `providerID` was correct but `modelID` became just the first segment — the rest was discarded. The subsequent model lookup failed with "Model not found".

Fix by switching from `split("/")` to `indexOf("/")` + `slice`, which splits only on the first slash. Applied consistently to both the `/model set` command handler in `bot.ts` and the `parseModelRef` helper in `opencode.ts`. The `parseModelRef` change also adds a dedicated guard for values with no slash at all (throws `OpencodeModelFormatError`).

Test changes:
- `bot-logic.commands.test.ts`: add `parseModelCommand` case for a `provider/org/model` ref.
- `bot.handlers.test.ts`: add an `openrouter` provider to the `/model set` test mock and exercise the full handler path with a slash-in-model-ID ref.